### PR TITLE
Automated Changelog Entry for 0.6.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,18 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.6.2
+
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-topbar-text/compare/first-commit...1b3387949dba95682703e865c2e6663f8ef356c0))
+
+### Maintenance and upkeep improvements
+
+- Use maintainer tools base setup on CI [#1](https://github.com/jupyterlab-contrib/jupyterlab-topbar-text/pull/1) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-topbar-text/graphs/contributors?from=2021-12-06&to=2021-12-07&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-topbar-text+involves%3Ajtpio+updated%3A2021-12-06..2021-12-07&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.6.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab-contrib/jupyterlab-topbar-text  |
| Branch  | main  |
| Version Spec | 0.6.2 |
| Since | first-commit |